### PR TITLE
Min range size

### DIFF
--- a/R/defaultThemes.R
+++ b/R/defaultThemes.R
@@ -142,7 +142,7 @@ initDefaultTheme <- function(){
   theme$y_grid_count_strict <- TRUE # do not allow extra ticks to be attached by y_tick_margin (which could lead to y_grid_count being violated)
   theme$y_tick_margin <- 0.15        # at least 50% of top/bottom tick range must be empty if y_grid_count_strict is FALSE
   theme$preferred_y_gap_sizes <- c(25, 20, 15, 10, 5, 2.5, 1, 0.5)
-  theme$y_range_min_size <- 40
+  theme$y_range_min_size <- NULL
   theme
 }
 

--- a/R/defaultThemes.R
+++ b/R/defaultThemes.R
@@ -142,6 +142,7 @@ initDefaultTheme <- function(){
   theme$y_grid_count_strict <- TRUE # do not allow extra ticks to be attached by y_tick_margin (which could lead to y_grid_count being violated)
   theme$y_tick_margin <- 0.15        # at least 50% of top/bottom tick range must be empty if y_grid_count_strict is FALSE
   theme$preferred_y_gap_sizes <- c(25, 20, 15, 10, 5, 2.5, 1, 0.5)
+  theme$y_range_min_size <- 40
   theme
 }
 

--- a/R/tsplot.R
+++ b/R/tsplot.R
@@ -125,12 +125,14 @@ tsplot.list <- function(tsl,
   tsl_r <- range(as.numeric(unlist(tsl)),na.rm = T)
   tsl_r_true <- tsl_r
   
-  # Restrict y range to at least theme$y_range_min_size
-  tsl_r_size <- diff(tsl_r)
-  if(tsl_r_size < theme$y_range_min_size) {
-    tsl_r_mid <- 0.5*tsl_r_size + tsl_r[1]
-    half_min_range_size <- 0.5*theme$y_range_min_size
-    tsl_r <- c(tsl_r_mid - half_min_range_size, tsl_r_mid + half_min_range_size)
+  if(!is.null(theme$y_range_min_size)) {
+    # Restrict y range to at least theme$y_range_min_size
+    tsl_r_size <- diff(tsl_r)
+    if(tsl_r_size < theme$y_range_min_size) {
+      tsl_r_mid <- 0.5*tsl_r_size + tsl_r[1]
+      half_min_range_size <- 0.5*theme$y_range_min_size
+      tsl_r <- c(tsl_r_mid - half_min_range_size, tsl_r_mid + half_min_range_size)
+    }
   }
   
   if(!is.null(tsr)) {
@@ -138,11 +140,13 @@ tsplot.list <- function(tsl,
     tsr_r <- range(unlist(tsr))
     tsr_r_true <- tsr_r
     
-    tsr_r_size <- diff(tsr_r)
-    if(tsr_r_size < theme$y_range_min_size) {
-      tsr_r_mid <- 0.5*tsr_r_size + tsr_r[1]
-      half_min_range_size <- 0.5*theme$y_range_min_size
-      tsr_r <- c(tsr_r_mid - half_min_range_size, tsr_r_mid + half_min_range_size)
+    if(!is.null(theme$y_range_min_size)) {
+      tsr_r_size <- diff(tsr_r)
+      if(tsr_r_size < theme$y_range_min_size) {
+        tsr_r_mid <- 0.5*tsr_r_size + tsr_r[1]
+        half_min_range_size <- 0.5*theme$y_range_min_size
+        tsr_r <- c(tsr_r_mid - half_min_range_size, tsr_r_mid + half_min_range_size)
+      }
     }
   }
   

--- a/R/tsplot.R
+++ b/R/tsplot.R
@@ -123,8 +123,28 @@ tsplot.list <- function(tsl,
   # if(!is.null(tsr)) cnames <- names(tsr) 
   
   tsl_r <- range(as.numeric(unlist(tsl)),na.rm = T)
-  tsr <- .sanitizeTsr(tsr)
-  if(!is.null(tsr)) tsr_r <- range(unlist(tsr))
+  tsl_r_true <- tsl_r
+  
+  # Restrict y range to at least theme$y_range_min_size
+  tsl_r_size <- diff(tsl_r)
+  if(tsl_r_size < theme$y_range_min_size) {
+    tsl_r_mid <- 0.5*tsl_r_size + tsl_r[1]
+    half_min_range_size <- 0.5*theme$y_range_min_size
+    tsl_r <- c(tsl_r_mid - half_min_range_size, tsl_r_mid + half_min_range_size)
+  }
+  
+  if(!is.null(tsr)) {
+    tsr <- .sanitizeTsr(tsr)
+    tsr_r <- range(unlist(tsr))
+    tsr_r_true <- tsr_r
+    
+    tsr_r_size <- diff(tsr_r)
+    if(tsr_r_size < theme$y_range_min_size) {
+      tsr_r_mid <- 0.5*tsr_r_size + tsr_r[1]
+      half_min_range_size <- 0.5*theme$y_range_min_size
+      tsr_r <- c(tsr_r_mid - half_min_range_size, tsr_r_mid + half_min_range_size)
+    }
+  }
   
   
   
@@ -142,7 +162,7 @@ tsplot.list <- function(tsl,
   } else{
     if(left_as_bar) return("Finding ticks automatically when stacking values is not supported yet. Please use manual_value_ticks.")
     
-    left_ticks <- do.call(find_ticks_function, list(tsl_r, theme$y_grid_count, theme$preferred_y_gap_sizes))
+    left_ticks <- do.call(find_ticks_function, list(tsl_r, tsl_r_true, theme$y_grid_count, theme$preferred_y_gap_sizes))
     left_y <- list(y_range = range(left_ticks), y_ticks = left_ticks)
     # return("Only works with manual value ticks...")
   }
@@ -155,7 +175,7 @@ tsplot.list <- function(tsl,
       right_y <- list(y_range = range(manual_value_ticks_r),
                       y_ticks = manual_value_ticks_r)  
     } else {
-      right_ticks <- do.call(find_ticks_function, list(tsr_r, length(left_ticks), theme$preferred_y_gap_sizes))
+      right_ticks <- do.call(find_ticks_function, list(tsr_r, tsr_r_true, length(left_ticks), theme$preferred_y_gap_sizes))
       right_y <- list(y_range = range(right_ticks), y_ticks = right_ticks)
     }
   }

--- a/R/utils.R
+++ b/R/utils.R
@@ -123,13 +123,13 @@ findGapSize <- function(r,tick_count){
 }
 
 #'@export
-findTicks <- function(r,tick_count,preferred_gap_sizes){
+findTicks <- function(r, true_r, tick_count, preferred_gap_sizes){
   # potential tick count needs to sorted otherwise, 
   # automatic selection of
   gaps <- findGapSize(r=r,sort(tick_count))
   lb <- (r[1] %/% gaps) * gaps
   d <- ceiling(diff(r))
-  tms <- (d %/% gaps) + 1
+  tms <- pmax(1, d %/% gaps)
   ub <- lb + (tms * gaps)  
   
   if(length(tick_count) == 1) {
@@ -137,10 +137,10 @@ findTicks <- function(r,tick_count,preferred_gap_sizes){
   }
   
   # correct algorithm when values are below upper bound
-  ub_too_low <- ub <= r[2]
+  ub_too_low <- ub <= true_r[2]
   while(any(ub_too_low)) {
     ub[ub_too_low] <- ub[ub_too_low] + gaps[ub_too_low]
-    ub_too_low <- ub <= r[2]
+    ub_too_low <- ub <= true_r[2]
   }
   
   seqs <- list()


### PR DESCRIPTION
**Not entirely sure how to handle PRs on PRs**
Probably best to first merge this one.

Automatic finding of y ranges results in ts always
being scaled to fill as much of the plot height as possible.
If this is undesired (e.g. when trying to accentuate that a
series is relatively stable) this parameter allows fixing the
total range of y values to a certain minimal value.