### PR TITLE
Fix ranging in findTicks

### DIFF
--- a/R/utils.R
+++ b/R/utils.R
@@ -95,20 +95,22 @@ findTicks <- function(r, true_r, tick_count, preferred_gap_sizes){
   # automatic selection of
   gaps <- findGapSize(r=r,sort(tick_count))
   lb <- (r[1] %/% gaps) * gaps
-  d <- ceiling(diff(r))
-  tms <- pmax(1, d %/% gaps)
-  ub <- lb + (tms * gaps)  
+  
+  ub <- lb + ((tick_count - 1) * gaps)  
   
   if(length(tick_count) == 1) {
     ub <- lb + ((tick_count - 1)*gaps)
   }
   
-  # correct algorithm when values are below upper bound
-  ub_too_low <- ub <= true_r[2]
-  while(any(ub_too_low)) {
-    ub[ub_too_low] <- ub[ub_too_low] + gaps[ub_too_low]
-    ub_too_low <- ub <= true_r[2]
-  }
+  # nudge the generated range around a bit to ensure the series are more or less "centered"
+  # i.e. there are no empty ticks
+  lb_too_low <- r[1] > lb + gaps
+  lb[lb_too_low] <- lb[lb_too_low] + gaps[lb_too_low]/2
+  ub[lb_too_low] <- ub[lb_too_low] + gaps[lb_too_low]/2
+  
+  ub_too_high <- r[2] < ub - gaps
+  lb[ub_too_high] <- lb[ub_too_high] - gaps[ub_too_high]/2
+  ub[ub_too_high] <- ub[ub_too_high] - gaps[ub_too_high]/2
   
   seqs <- list()
   for(i in seq_along(gaps)) {


### PR DESCRIPTION
Two major changes:
1) the upper bound of the generated range is now calculated
   based on the desired number of ticks and not based on "best fit"
   (the tms approach). This prevents findGaps from returning too
   few ticks
2) Since the new approach in 1) can lead to an entire empty tick
   at either end (well, probably just the top) of the range, the
   series are now nudged toward the middle of that range by half
   a tick if this is the case