### PR TITLE
Strip prefix from legend then tsl supplied as named param

### DIFF
--- a/R/tsplot.R
+++ b/R/tsplot.R
@@ -176,6 +176,7 @@ tsplot.list <- function(...,
 ){
   
   tsl <- c(...)
+  names(tsl) <- gsub("^tsl.(.*)", "\\1", names(tsl))
   
   if(is.null(theme)) theme <- init_tsplot_theme()
   # thanks to @christophsax for that snippet.


### PR DESCRIPTION
c(...) would prefix the names of the resulting list with the name of the
parameter ("tsl."). This is undesired.

Fixes #87