### PR TITLE
Encapsulate plot title stuff in add_title

### DIFF
--- a/R/add_title.R
+++ b/R/add_title.R
@@ -1,0 +1,46 @@
+add_title <- function(plot_title = NULL,
+                      plot_subtitle = NULL,
+                      plot_subtitle_r = NULL,
+                      theme) {
+  par(fig = c(0, 1, 0, 1),
+      oma = c(0.2, 3, 2, 1),
+      mar = c(0, 0, 0, 0),
+      new = TRUE)
+  plot(0, 0, type="n", bty="n", xaxt="n", yaxt="n")
+    
+  if(!is.null(plot_title)){
+    
+    if(!any(is.na(theme$title_transform))){
+      plot_title <- do.call(theme$title_transform,
+                            list(plot_title))
+    } 
+    title(main = plot_title, adj = theme$title_adj,
+          line = theme$title_line,
+          outer = theme$title_outer,
+          cex.main = theme$title_cex.main)    
+  }
+  
+  if(!is.null(plot_subtitle)){
+    if(!is.null(theme$subtitle_transform)){
+      plot_subtitle <- do.call(theme$subtitle_transform,
+                               list(plot_subtitle))
+    } 
+    mtext(plot_subtitle, adj = theme$title_adj,
+          line = theme$subtitle_line,
+          outer = theme$subtitle_outer,
+          cex = theme$subtitle_cex)    
+  }
+  
+  
+  if(!is.null(plot_subtitle_r)){
+    if(!is.null(theme$subtitle_transform)){
+      plot_subtitle_r <- do.call(theme$subtitle_transform,
+                                 list(plot_subtitle_r))
+    } 
+    mtext(plot_subtitle_r,
+          adj = theme$subtitle_adj_r,
+          line = theme$subtitle_line,
+          outer = theme$subtitle_outer,
+          cex = theme$subtitle_cex)    
+  }
+}

--- a/R/tsplot.R
+++ b/R/tsplot.R
@@ -467,40 +467,8 @@ tsplot.list <- function(...,
   }
   
   # add title and subtitle
-  if(!is.null(plot_title)){
-    if(!any(is.na(theme$title_transform))){
-      plot_title <- do.call(theme$title_transform,
-                            list(plot_title))
-    } 
-    title(main = plot_title, adj = theme$title_adj,
-          line = theme$title_line,
-          outer = theme$title_outer,
-          cex.main = theme$title_cex.main)    
-  }
+  add_title(plot_title, plot_subtitle, plot_subtitle_r, theme)
   
-  if(!is.null(plot_subtitle)){
-    if(!is.null(theme$subtitle_transform)){
-      plot_subtitle <- do.call(theme$subtitle_transform,
-                               list(plot_subtitle))
-    } 
-    mtext(plot_subtitle, adj = theme$title_adj,
-          line = theme$subtitle_line,
-          outer = theme$subtitle_outer,
-          cex = theme$subtitle_cex)    
-  }
-  
-  
-  if(!is.null(plot_subtitle_r)){
-    if(!is.null(theme$subtitle_transform)){
-      plot_subtitle_r <- do.call(theme$subtitle_transform,
-                                 list(plot_subtitle_r))
-    } 
-    mtext(plot_subtitle_r,
-          adj = theme$subtitle_adj_r,
-          line = theme$subtitle_line,
-          outer = theme$subtitle_outer,
-          cex = theme$subtitle_cex)    
-  }
   # return axes and tick info, as well as theme maybe? 
   if(!quiet){
     output <- list(left_range = tsl_r,


### PR DESCRIPTION
Added a helper for adding titles.
Main reason was to be able to start a new "layer" for all titles instead
of doing so for each element separately inside its !is.null clause

Fixes #89