### PR TITLE
Add theme parameters for tick length

### DIFF
--- a/R/themes.R
+++ b/R/themes.R
@@ -41,6 +41,8 @@
 #' @param tcl_yearly_tick numeric, same as base \code{\link{plot}} tcl parameter defaults to -.75,
 #' @param lwd_yearly_ticks numeric, width of yearly ticks, defaults to 1.5.
 #' @param lwd_quarterly_ticks numeric, width of yearly ticks, defaults to 1.
+#' @param tck_yearly_ticks numeric, length of yearly ticks. Suited values range from -0.1 to 0.1, defaults to -0.05.
+#' @param tck_quarterly_ticks numeric, length of quarterly ticks. See tck_yearly_ticks, defaults to -0.04
 #' @param label_pos character, currently undocumented. sorry. defaults to "mid".
 #' @param show_left_y_axis logical: should left y axis be shown, defaults to TRUE.
 #' @param show_right_y_axis logical: should left y axis be shown, defaults to TRUE.
@@ -136,6 +138,8 @@ init_tsplot_theme <- function(
   tcl_yearly_tick = -.75,
   lwd_yearly_ticks = 1.5,
   lwd_quarterly_ticks = 1,
+  tck_yearly_ticks = -0.05,
+  tck_quarterly_ticks = -0.04,
   label_pos = "mid",
   show_left_y_axis = TRUE,
   show_right_y_axis = TRUE,

--- a/R/themes.R
+++ b/R/themes.R
@@ -139,7 +139,7 @@ init_tsplot_theme <- function(
   lwd_yearly_ticks = 1.5,
   lwd_quarterly_ticks = 1,
   tck_yearly_ticks = -0.05,
-  tck_quarterly_ticks = -0.04,
+  tck_quarterly_ticks = -0.02,
   label_pos = "mid",
   show_left_y_axis = TRUE,
   show_right_y_axis = TRUE,

--- a/R/tsplot.R
+++ b/R/tsplot.R
@@ -410,21 +410,28 @@ tsplot.list <- function(...,
     if(theme$label_pos == "start"){
       axis(1,global_x$yearly_tick_pos,labels = global_x$yearly_tick_pos,
            lwd.ticks = theme$lwd_yearly_ticks,
-           tcl = theme$tcl_yearly_tick)    
+           tcl = theme$tcl_yearly_tick,
+           tck = theme$tck_yearly_tick)    
     } else{
       axis(1,global_x$yearly_tick_pos,labels = F,
            lwd.ticks = theme$lwd_yearly_ticks,
-           tcl = theme$tcl_yearly_tick)
+           tcl = theme$tcl_yearly_tick,
+           tck = theme$tck_yearly_tick)
     }
   }
   
   if(theme$quarterly_ticks){
+    overlap <- global_x$quarterly_tick_pos %in% global_x$yearly_tick_pos
+    q_ticks <- global_x$quarterly_tick_pos[!overlap]
+    q_labels <- global_x$year_labels_middle_q[!overlap]
     if(theme$label_pos == "mid"){
-      axis(1,global_x$quarterly_tick_pos,labels = global_x$year_labels_middle_q,
-           lwd.ticks = theme$lwd_quarterly_ticks)    
+      axis(1, q_ticks,labels = q_labels,
+           lwd.ticks = theme$lwd_quarterly_ticks,
+           tck = theme$tck_quarterly_ticks)    
     } else{
-      axis(1,global_x$quarterly_tick_pos,labels = F,
-           lwd.ticks = theme$lwd_quarterly_ticks)
+      axis(1, q_ticks, labels = F,
+           lwd.ticks = theme$lwd_quarterly_ticks,
+           tck = theme$tck_quarterly_ticks)
     }
   }
   

--- a/man/init_tsplot_theme.Rd
+++ b/man/init_tsplot_theme.Rd
@@ -22,12 +22,13 @@ init_tsplot_theme(margins = c(NA, 4, 3, 3) + 0.1,
   y_las = 2, lwd_ticks_1 = 1.5, lwd_ticks_2 = 1, yearly_ticks = TRUE,
   quarterly_ticks = TRUE, monthly_ticks = FALSE,
   tcl_quarterly_tick_tcl = -0.5, tcl_yearly_tick = -0.75,
-  lwd_yearly_ticks = 1.5, lwd_quarterly_ticks = 1, label_pos = "mid",
-  show_left_y_axis = TRUE, show_right_y_axis = TRUE, y_grid_count = c(5,
-  6, 8, 10), show_y_grids = TRUE, y_grid_color = "#CCCCCC",
-  y_grid_count_strict = FALSE, y_tick_margin = 0.15,
-  preferred_y_gap_sizes = c(25, 20, 15, 10, 5, 2.5, 1, 0.5),
-  y_range_min_size = NULL, legend_col = 1, legend_margin_top = 0.45,
+  lwd_yearly_ticks = 1.5, lwd_quarterly_ticks = 1,
+  tck_yearly_ticks = -0.05, tck_quarterly_ticks = -0.04,
+  label_pos = "mid", show_left_y_axis = TRUE, show_right_y_axis = TRUE,
+  y_grid_count = c(5, 6, 8, 10), show_y_grids = TRUE,
+  y_grid_color = "#CCCCCC", y_grid_count_strict = FALSE,
+  y_tick_margin = 0.15, preferred_y_gap_sizes = c(25, 20, 15, 10, 5, 2.5, 1,
+  0.5), y_range_min_size = NULL, legend_col = 1, legend_margin_top = 0.45,
   title_outer = FALSE, title_adj = 0, title_line = 1.8,
   title_cex.main = 1, title_transform = NA, subtitle_adj = 0,
   subtitle_outer = FALSE, subtitle_line = 0.5, subtitle_cex.main = 1,
@@ -101,6 +102,10 @@ to FALSE.}
 \item{lwd_yearly_ticks}{numeric, width of yearly ticks, defaults to 1.5.}
 
 \item{lwd_quarterly_ticks}{numeric, width of yearly ticks, defaults to 1.}
+
+\item{tck_yearly_ticks}{numeric, length of yearly ticks. Suited values range from -0.1 to 0.1, defaults to -0.05.}
+
+\item{tck_quarterly_ticks}{numeric, length of quarterly ticks. See tck_yearly_ticks, defaults to -0.04}
 
 \item{label_pos}{character, currently undocumented. sorry. defaults to "mid".}
 


### PR DESCRIPTION
tck_yearly_ticks and tck_quarterly_ticks
Note: They should be negative for the ticks to appear below the line
axis and range somewhere in [-0.1, -0.01].

Fixes #12