### PR TITLE
Add check for length 1 time series

### DIFF
--- a/R/tsplot.R
+++ b/R/tsplot.R
@@ -186,6 +186,10 @@ tsplot.list <- function(...,
   
   tsl <- c(...)
   
+  if(any(sapply(tsl, length)) == 1) {
+    stop("Time series of length 1 are not supported!")
+  }
+  
   if(is.null(theme)) theme <- init_tsplot_theme()
   
   if(left_as_bar && relative_bar_chart) {


### PR DESCRIPTION
These cause all sorts of problems which are not obviously connected to
the fact that length 1 series are inputted. Plotting single points does
not make much sense anyway so it just stops if any series of length 1
are provided.

Maybe it would be possible to support sets of time series of which only
some are length 1 but is that necessary?

Fixes #134