### PR TITLE
Recycle per-line parameters, truncate point params for tsr

### DIFF
--- a/R/low_level_line_plots.R
+++ b/R/low_level_line_plots.R
@@ -12,8 +12,6 @@ draw_ts_lines.ts <- function(x, theme = NULL,
 
 draw_ts_lines.list <- function(x, theme = NULL){
   nts <- length(x)
-  op <- rep(theme$overplot, ceiling(nts/length(theme$overplot)))
-  ops <- rep(theme$overplot_symbol, ceiling(nts/length(theme$overplot_symbol)))
   
   for (i in 1:nts) {
     xx <- as.numeric(time(x[[i]]))
@@ -25,15 +23,11 @@ draw_ts_lines.list <- function(x, theme = NULL){
     }
     
     lines(xx,yy,
-          col = theme$line_colors[[i]],
-          lwd = ifelse(length(theme$lwd) > 1,
-                       theme$lwd[i],
-                       theme$lwd),
-          lty = ifelse(length(theme$lty) > 1,
-                       theme$lty[i],
-                       theme$lty),
-          type = ifelse(op[i], "o", "l"),
-          pch = ops[i]
+          col = theme$line_colors[i],
+          lwd = theme$lwd[i],
+          lty = theme$lty[i],
+          type = ifelse(theme$show_points[i], "o", "l"),
+          pch = theme$point_symbol[i]
     )
   }
   

--- a/R/tsplot.R
+++ b/R/tsplot.R
@@ -203,6 +203,20 @@ tsplot.list <- function(...,
   
   if(is.null(theme)) theme <- init_tsplot_theme()
   
+  # Expand per-line parameters for recycling
+  total_n_ts <- length(tsl) + length(tsr)
+  expand_param <- function(theme, param_name) {
+    rep(theme[[param_name]], ceiling(total_n_ts/length(theme[[param_name]])))
+  }
+  
+  
+  theme$line_colors <- expand_param(theme, "line_colors")
+  theme$lwd <- expand_param(theme, "lwd")
+  theme$lty <- expand_param(theme, "lty")
+  theme$show_points <- expand_param(theme, "show_points")
+  theme$point_symbol <- expand_param(theme, "point_symbol")
+  
+  
   if(left_as_bar && relative_bar_chart) {
     # Normalize ts
     if(group_bar_chart) {
@@ -527,8 +541,10 @@ tsplot.list <- function(...,
       start_r <- (total_le - (length(tsr)-1)):total_le
       
       tt_r$line_colors <- tt_r$line_colors[start_r]
-      if(!all(is.na(tt_r$lwd[start_r]))) tt_r$lwd <- na.omit(tt_r$lwd[start_r])
-      if(!all(is.na(tt_r$lty[start_r]))) tt_r$lty <- na.omit(tt_r$lty[start_r])
+      tt_r$lwd <- tt_r$lwd[start_r]
+      tt_r$lty <- tt_r$lty[start_r]
+      tt_r$show_points <- tt_r$show_points[start_r]
+      tt_r$point_symbol <- tt_r$point_symbol[start_r]
     }
     draw_ts_lines(tsr,theme = tt_r)
     


### PR DESCRIPTION
Previously tsplot relied on the user specifying the per line parameters
(lty, lwd, line_colors, show_points, point_symbol) as either exactly one
value or enough values to cover all series. If, however, 5 series were
supplied with only 3 line types, the last two series would get an lty of
NA.
Now these parameters are repeated until there are enough values for all
series, thereby effectively recycling the vectors.

Fixes #145

**Before:**
```R
tsplot(gimme_some_ts(3), theme = init_tsplot_theme(line_colors = c("black", "red"), show_points = TRUE))
 Error in theme$line_colors[[i]] : subscript out of bounds 
```

![rplot08](https://user-images.githubusercontent.com/32675029/38917904-a24acdce-42db-11e8-9cf6-91ba5ebce4a6.png)

**After:**

```R
tsplot(gimme_some_ts(3), theme = init_tsplot_theme(line_colors = c("black", "red"), show_points = TRUE))
```

![rplot09](https://user-images.githubusercontent.com/32675029/38917927-b3d67ec6-42db-11e8-85c7-9b9750f0bbee.png)


Does that make sense?