### PR TITLE
Add manual_ticks_x and x_tick_dt

### DIFF
--- a/R/themes.R
+++ b/R/themes.R
@@ -151,6 +151,7 @@ init_tsplot_theme <- function(
   y_grid_color = "#CCCCCC",
   y_grid_count_strict = FALSE,
   y_tick_margin = 0.15,
+  x_tick_dt = 1,
   preferred_y_gap_sizes = c(25, 20, 15, 10, 5, 2.5, 1, 0.5),
   y_range_min_size = NULL,
   legend_col = 1,

--- a/R/themes.R
+++ b/R/themes.R
@@ -56,6 +56,8 @@
 #' @param y_grid_count_strict logical should we strictly stick to preferred y grid count? Defaults to FALSE. 
 #' @param y_tick_margin numeric, minimal percentage of horizontal grid that needs to be clean, i.e., 
 #' without lines or bars. Defaults to 0.15 (15 percent).
+#' @param x_tick_dt numeric The distance between ticks on the x axis in years. The first tick will always be at the
+#' start of the plotted time series. Defaults to 1
 #' @param preferred_y_gap_sizes numeric c(25, 20, 15, 10, 5, 2.5, 1, 0.5),
 #' @param y_range_min_size = NULL  ,
 #' @param legend_col integer number of columns for the legend, defaults to 3.

--- a/R/tsplot.R
+++ b/R/tsplot.R
@@ -17,6 +17,7 @@
 #' @param manual_date_ticks character vector of manual date ticks.
 #' @param manual_value_ticks_l numeric vector, forcing ticks to the left y-axis 
 #' @param manual_value_ticks_r numeric vector, forcing ticks to the right y-axis 
+#' @param manual_ticks_x numeric vector, forcing ticks on the x axis
 #' @param theme list of default plot output parameters. Defaults to NULL, which leads to \code{\link{init_tsplot_theme}} being called. Please see the vignette for details about tweaking themes.
 #' @param quiet logical suppress output, defaults to TRUE.
 #' @param auto_legend logical should legends be printed automatically, defaults to TRUE.

--- a/R/tsplot.R
+++ b/R/tsplot.R
@@ -39,6 +39,7 @@ tsplot <- function(...,
                    manual_date_ticks = NULL,
                    manual_value_ticks_l = NULL,
                    manual_value_ticks_r = NULL,
+                   manual_ticks_x = NULL,
                    theme = NULL,
                    quiet = TRUE,
                    auto_legend = TRUE){
@@ -61,6 +62,7 @@ tsplot.ts <- function(...,
                       manual_date_ticks = NULL,
                       manual_value_ticks_l = NULL,
                       manual_value_ticks_r = NULL,
+                      manual_ticks_x = NULL,
                       theme = NULL,
                       quiet = TRUE,
                       auto_legend = TRUE
@@ -81,6 +83,7 @@ tsplot.ts <- function(...,
          overall_ylim = overall_ylim,
          manual_value_ticks_l = manual_value_ticks_l,
          manual_value_ticks_r = manual_value_ticks_r,
+         manual_ticks_x = manual_ticks_x,
          theme = theme,
          quiet = quiet,
          auto_legend = auto_legend)
@@ -102,6 +105,7 @@ tsplot.mts <- function(...,
                        manual_date_ticks = NULL,
                        manual_value_ticks_l = NULL,
                        manual_value_ticks_r = NULL,
+                       manual_ticks_x = NULL,
                        theme = NULL,
                        quiet = TRUE,
                        auto_legend = TRUE){
@@ -124,6 +128,7 @@ tsplot.mts <- function(...,
            manual_date_ticks = manual_date_ticks,
            manual_value_ticks_l = manual_value_ticks_l,
            manual_value_ticks_r = manual_value_ticks_r,
+           manual_ticks_x = manual_ticks_x,
            theme = theme,
            quiet = quiet,
            auto_legend = auto_legend)
@@ -146,6 +151,7 @@ tsplot.zoo <- function(...,
                        manual_date_ticks = NULL,
                        manual_value_ticks_l = NULL,
                        manual_value_ticks_r = NULL,
+                       manual_ticks_x = NULL,
                        theme = NULL,
                        quiet = TRUE,
                        auto_legend = TRUE) {
@@ -168,6 +174,7 @@ tsplot.xts <- function(...,
                        manual_date_ticks = NULL,
                        manual_value_ticks_l = NULL,
                        manual_value_ticks_r = NULL,
+                       manual_ticks_x = NULL,
                        theme = NULL,
                        quiet = TRUE,
                        auto_legend = TRUE) {
@@ -190,6 +197,7 @@ tsplot.list <- function(...,
                         manual_date_ticks = NULL,
                         manual_value_ticks_l = NULL,
                         manual_value_ticks_r = NULL,
+                        manual_ticks_x = NULL,
                         theme = NULL,
                         quiet = TRUE,
                         auto_legend = TRUE
@@ -327,7 +335,7 @@ tsplot.list <- function(...,
   
   # CANVAS OPTIONS START #########################################
   # so far manual date ticks are ignored.
-  global_x <- getGlobalXInfo(tsl,tsr,fill_up_start = fill_up_start)
+  global_x <- getGlobalXInfo(tsl,tsr,fill_up_start = fill_up_start, theme$x_tick_dt, manual_ticks_x)
   
   # y can't be global in the first place, cause 
   # tsr and tsl have different scales.... 
@@ -475,7 +483,7 @@ tsplot.list <- function(...,
   
   # Global X-Axis ###################
   if(theme$yearly_ticks){
-    if(theme$label_pos == "start"){
+    if(theme$label_pos == "start" || theme$x_tick_dt != 1 || !is.null(manual_ticks_x)){
       axis(1,global_x$yearly_tick_pos,labels = global_x$yearly_tick_pos,
            lwd.ticks = theme$lwd_yearly_ticks,
            tcl = theme$tcl_yearly_tick)    
@@ -486,7 +494,7 @@ tsplot.list <- function(...,
     }
   }
   
-  if(theme$quarterly_ticks){
+  if(theme$quarterly_ticks && theme$x_tick_dt == 1 && is.null(manual_ticks_x)){
     overlap <- global_x$quarterly_tick_pos %in% global_x$yearly_tick_pos
     q_ticks <- global_x$quarterly_tick_pos[!overlap]
     q_labels <- global_x$year_labels_middle_q[!overlap]

--- a/R/utils.R
+++ b/R/utils.R
@@ -14,7 +14,7 @@ compute_decimal_time <- function(v,f){
 
 # function is called by tsplot, do not need to export
 # it but let's write a minimal comment on what it does.
-getGlobalXInfo <- function(tsl,tsr,fill_up_start){
+getGlobalXInfo <- function(tsl, tsr, fill_up_start, dt, manual_ticks){
   global_x <- list()
   
   if(!is.null(tsr)){
@@ -23,32 +23,43 @@ getGlobalXInfo <- function(tsl,tsr,fill_up_start){
     all_ts <- tsl
   }
   
-  all_ts_ext <- lapply(all_ts,fill_year_with_nas,fill_up_start = fill_up_start)
-  global_x$x_range <- range(unlist(lapply(all_ts_ext,time)))
+  if(is.null(manual_ticks)) {
+    all_ts_ext <- lapply(all_ts,fill_year_with_nas,fill_up_start = fill_up_start)
+    global_x$x_range <- range(unlist(lapply(all_ts_ext,time)))
+    # Yearly tick positions
+    global_x$yearly_tick_pos <- seq(global_x$x_range[1], global_x$x_range[2] + dt, dt)
+    
+    # labels
+    global_x$year_labels_start <- seq(global_x$x_range[1], global_x$x_range[2] + dt, dt)
+  } else {
+    global_x$x_range <- range(manual_ticks)
+    global_x$yearly_tick_pos <- manual_ticks
+    global_x$year_labels_start <- manual_ticks
+  }
   
   global_x$min_year <- trunc(global_x$x_range[1])
   global_x$max_year <- trunc(global_x$x_range[2])
   
-  # Yearly tick positions
-  global_x$yearly_tick_pos <- global_x$min_year:global_x$max_year
-  global_x$quarterly_tick_pos <- seq(from = global_x$min_year,
-                                     to = global_x$max_year,
-                                     by = .25)
-  global_x$monthly_tick_pos <- seq(from = global_x$min_year,
-                                   to = global_x$max_year,
-                                   by = 1/12)
-  
-  # labels
-  global_x$year_labels_start <- global_x$min_year:global_x$max_year
-  global_x$year_labels_middle_q <- ifelse(global_x$quarterly_tick_pos -
-                                          floor(global_x$quarterly_tick_pos) == 0.5,
-                                        as.character(floor(global_x$quarterly_tick_pos)),
-                                        NA)
-  global_x$year_labels_middle_m <- ifelse(global_x$monthly_tick_pos -
-                                          floor(global_x$monthly_tick_pos) == 0.5,
-                                        as.character(floor(global_x$monthly_tick_pos)),
-                                        NA)
-                                        
+  if(dt == 1) {
+    global_x$quarterly_tick_pos <- seq(from = global_x$min_year,
+                                       to = global_x$max_year,
+                                       by = .25)
+    # global_x$monthly_tick_pos <- seq(from = global_x$min_year,
+    #                                  to = global_x$max_year,
+    #                                  by = 1/12)
+    global_x$year_labels_middle_q <- ifelse(global_x$quarterly_tick_pos -
+                                            floor(global_x$quarterly_tick_pos) == 0.5,
+                                          as.character(floor(global_x$quarterly_tick_pos)),
+                                          NA)
+    # global_x$year_labels_middle_m <- ifelse(global_x$monthly_tick_pos -
+    #                                       floor(global_x$monthly_tick_pos) == 0.5,
+    #                                     as.character(floor(global_x$monthly_tick_pos)),
+    #                                      NA)
+  } else {
+    global_x$quarterly_tick_pos <- NA
+    global_x$year_labels_middle_q <- NA
+  }
+                                          
   global_x
 }
 

--- a/man/init_tsplot_theme.Rd
+++ b/man/init_tsplot_theme.Rd
@@ -25,7 +25,7 @@ init_tsplot_theme(margins = c(NA, 4, 3, 3) + 0.1,
   tcl_yearly_ticks = -0.75, tcl_quarterly_ticks = -0.4, label_pos = "mid",
   show_left_y_axis = TRUE, show_right_y_axis = TRUE, y_grid_count = c(5,
   6, 8, 10), show_y_grids = TRUE, y_grid_color = "#CCCCCC",
-  y_grid_count_strict = FALSE, y_tick_margin = 0.15,
+  y_grid_count_strict = FALSE, y_tick_margin = 0.15, x_tick_dt = 1,
   preferred_y_gap_sizes = c(25, 20, 15, 10, 5, 2.5, 1, 0.5),
   y_range_min_size = NULL, legend_col = 1, legend_margin_top = 0.45,
   title_outer = FALSE, title_adj = 0, title_line = 1.8,
@@ -124,6 +124,9 @@ to FALSE.}
 
 \item{y_tick_margin}{numeric, minimal percentage of horizontal grid that needs to be clean, i.e., 
 without lines or bars. Defaults to 0.15 (15 percent).}
+
+\item{x_tick_dt}{numeric The distance between ticks on the x axis in years. The first tick will always be at the
+start of the plotted time series. Defaults to 1}
 
 \item{preferred_y_gap_sizes}{numeric c(25, 20, 15, 10, 5, 2.5, 1, 0.5),}
 

--- a/man/regularize.Rd
+++ b/man/regularize.Rd
@@ -4,12 +4,10 @@
 \alias{regularize}
 \title{Turn an Irregular Time Series to a Regular, ts-Based Series}
 \usage{
-regularize(x, df = "\%Y")
+regularize(x)
 }
 \arguments{
 \item{x}{an irregular time series object of class zoo or xts.}
-
-\item{df}{character denoting the interval in date notation. Currently only works for "\%Y".}
 }
 \description{
 Adds missing values to turn an irregular time series into a regular one. This function is currently experimental. Only works or target frequencies 1,2,4,12.

--- a/man/tsplot.Rd
+++ b/man/tsplot.Rd
@@ -9,8 +9,8 @@ tsplot(..., tsr = NULL, left_as_bar = FALSE, group_bar_chart = FALSE,
   plot_subtitle_r = NULL, find_ticks_function = "findTicks",
   fill_up_start = FALSE, overall_xlim = NULL, overall_ylim = NULL,
   manual_date_ticks = NULL, manual_value_ticks_l = NULL,
-  manual_value_ticks_r = NULL, theme = NULL, quiet = TRUE,
-  auto_legend = TRUE)
+  manual_value_ticks_r = NULL, manual_ticks_x = NULL, theme = NULL,
+  quiet = TRUE, auto_legend = TRUE)
 }
 \arguments{
 \item{...}{multiple objects of class ts or a list of time series. All objects passed through the ... parameter relate to the standard left y-axis.}
@@ -42,6 +42,8 @@ tsplot(..., tsr = NULL, left_as_bar = FALSE, group_bar_chart = FALSE,
 \item{manual_value_ticks_l}{numeric vector, forcing ticks to the left y-axis}
 
 \item{manual_value_ticks_r}{numeric vector, forcing ticks to the right y-axis}
+
+\item{manual_ticks_x}{numeric vector, forcing ticks on the x axis}
 
 \item{theme}{list of default plot output parameters. Defaults to NULL, which leads to \code{\link{init_tsplot_theme}} being called. Please see the vignette for details about tweaking themes.}
 


### PR DESCRIPTION
x_tick_dt is a theme parameter that allows specifying the distance
between x ticks in years.

manual_ticks_x is a tsplot parameter that allows completely overriding
the x axis.

If either x_tick_dt != 1 or manual_ticks_x are used, minor ticks are
always disabled and theme$label_pos == "start" is used.

See #151 


Sample usage:
```R
data(KOF)

tsplot(KOF$kofbarometer, theme = init_tsplot_theme(x_tick_dt = 2))
tsplot(window(KOF$kofbarometer, 1991, 1995), manual_ticks_x = c(1991, 1993, 1995))
tsplot(window(KOF$kofbarometer, 1991, 1995), manual_ticks_x = c(1991, 1993, 1995, 1997))
tsplot(window(KOF$kofbarometer, 1991, 1995), manual_ticks_x = c(1991, 1993))


# Fractions of years in dt are possible but produce weird results
# Fix, disallow, leave to user?
tsplot(KOF$kofbarometer, theme = init_tsplot_theme(x_tick_dt = 0.123))
```