### PR TITLE
Fix issue #203

### DIFF
--- a/R/tsplot.R
+++ b/R/tsplot.R
@@ -670,7 +670,7 @@ tsplot.list <- function(...,
          yaxs = theme$yaxs
     )
     
-    ci_left <- ci[names(tsl)]
+    ci_left <- ci[names(ci) %in% names(tsl)]
     draw_ts_ci(ci_left, theme)
   }
   
@@ -686,7 +686,7 @@ tsplot.list <- function(...,
          xaxs = theme$xaxs
     )
     
-    ci_right <- ci[names(tsr)]
+    ci_right <- ci[names(ci) %in% names(tsr)]
     draw_ts_ci(ci_right, tt_r)
   }
   


### PR DESCRIPTION
The indexing on lines 673 & 689 produced NA entries in ci_left and
ci_right which threw off draw_ts_ci (by not being ts objects).

Fixes #203