### PR TITLE
Bar.plot.margins

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: tstools
 Type: Package
-Version: 0.3.7.5
+Version: 0.3.7.7
 Title: A Time Series Toolbox for Official Statistics
 Description: Plot official statistics' time series conveniently: automatic legends, highlight windows, stacked bar chars with positive and negative contributions, sum-as-line option, two y-axes with automatic horizontal grids that fit both axes and other popular chart types. 'tstools' comes with a plethora of defaults to let you plot without setting an abundance of parameters first, but gives you the flexibility to tweak the defaults. In addition to charts, 'tstools' provides a super fast, 'data.table' backed time series I/O that allows the user to export / import long format, wide format and transposed wide format data to various file types. 
 Authors@R: c(

--- a/R/low_level_bar_plots.R
+++ b/R/low_level_bar_plots.R
@@ -9,27 +9,22 @@ draw_ts_bars.ts <- function(x, group_bar_chart = FALSE,
                           theme = NULL){
   ts_time <- time(x)
   frq <- frequency(x)
+  
+  # Bars are 1/frq wide, bar_gap is in % of alloted width
+  offset <- theme$bar_gap/(frq*200)
+  
   neg_0 <- x
   pos_0 <- x
   neg_0[x < 0] <- 0
   pos_0[!x < 0] <- 0
   
-  
-  rect(ts_time,0,
-       ts_time+1/frq,
+  rect(ts_time + offset,
+       pos_0,
+       ts_time + 1/frq - offset,
        neg_0,
        border = theme$bar_border,
        lwd = theme$bar_border_lwd,
        col = theme$bar_fill_color[1])
-  
-  rect(ts_time,pos_0,
-            ts_time+1/frq,
-            0,
-            border = theme$bar_border,
-            lwd = theme$bar_border_lwd,
-            col = theme$bar_fill_color[1])
-  
-  
 }
 
 

--- a/R/low_level_bar_plots.R
+++ b/R/low_level_bar_plots.R
@@ -41,8 +41,6 @@ draw_ts_bars <- function(x, group_bar_chart = FALSE, theme = NULL){
          lwd = theme$bar_border_lwd,
          col = theme$bar_fill_color[1:n_ts])  
   } else {
-    individual_offset_value <- theme$bar_gap/(n_ts*frq*200)
-    
     inter_group_offset_value <- theme$bar_group_gap/(frq*200)
     
     x_pos_raw <- t(c(ts_time) + rep(1, length(ts_time)) %*% t(seq(0, 1/frq, 1/(n_ts*frq))))
@@ -54,12 +52,24 @@ draw_ts_bars <- function(x, group_bar_chart = FALSE, theme = NULL){
       seq(x[1], x[n_ts+1], length.out = n_ts+1)
     })
     
-    inter_bar_offset <- t(rep(individual_offset_value, length(ts_time)) %*% t(c(1, rep(1, n_ts - 1), 1)))
+    x_left <- apply(x_pos_final, 2, function(x) {
+      grp <- x[n_ts+1] - x[1]
+      mar <- grp*theme$bar_gap/100
+      bar <- (grp - (n_ts - 1)*mar)/n_ts
+      seq(x[1], x[n_ts+1], by = bar + mar)
+    })
+    
+    x_right <- apply(x_pos_final, 2, function(x) {
+      grp <- x[n_ts+1] - x[1]
+      mar <- grp*theme$bar_gap/100
+      bar <- (grp - (n_ts - 1)*mar)/n_ts
+      seq(x[1] + bar, x[n_ts+1], by = bar + mar)
+    })
     
     rect(
-      x_pos_final[1:n_ts, ] + inter_bar_offset[1:n_ts,],
+      x_left,
       negatives,
-      x_pos_final[(1:n_ts)+1,] - inter_bar_offset[(1:n_ts)+1, ],
+      x_right,
       positives,
       border = theme$bar_border,
       lwd = theme$bar_border_lwd,

--- a/R/low_level_bar_plots.R
+++ b/R/low_level_bar_plots.R
@@ -1,115 +1,70 @@
-draw_ts_bars <- function(x, group_bar_chart = FALSE, theme = NULL,
-                       ...){
-  UseMethod("draw_ts_bars")
-} 
-
-
 #' @importFrom graphics rect
-draw_ts_bars.ts <- function(x, group_bar_chart = FALSE,
-                          theme = NULL){
-  ts_time <- time(x)
-  frq <- frequency(x)
+draw_ts_bars <- function(x, group_bar_chart = FALSE, theme = NULL){
+  n_ts <- length(x)
   
-  # Bars are 1/frq wide, bar_gap is in % of alloted width
-  offset <- theme$bar_gap/(frq*200)
+  # Matrixify tslist
+  x <- do.call(cbind, x)
   
-  neg_0 <- x
-  pos_0 <- x
-  neg_0[x < 0] <- 0
-  pos_0[!x < 0] <- 0
-  
-  rect(ts_time + offset,
-       pos_0,
-       ts_time + 1/frq - offset,
-       neg_0,
-       border = theme$bar_border,
-       lwd = theme$bar_border_lwd,
-       col = theme$bar_fill_color[1])
-}
-
-
-#' @importFrom graphics rect
-draw_ts_bars.list <- function(x,
-                            group_bar_chart = FALSE,
-                            theme = NULL){
-  if(length(x) == 1){
-    draw_ts_bars(x[[1]],
-               group_bar_chart =  group_bar_chart,
-               theme = theme)
-  } else{
-    m <- do.call("cbind",x)
-    draw_ts_bars(m,
-               group_bar_chart =  group_bar_chart,
-               theme = theme)  
-  }
-  
-}
-
-
-#' @importFrom graphics rect
-draw_ts_bars.mts <- function(x,
-                           group_bar_chart =  FALSE,
-                           theme = NULL){
-  if(is.null(group_bar_chart)) group_bar_chart <- FALSE
-
+  # "Remove" NAs (basically rect omits them anyway. Might even be better because of the borders)
   x[is.na(x)] <- 0
   
+  # Base rect coordinates
   ts_time <- time(x)
   frq <- frequency(x)
-  neg_0 <- x
-  pos_0 <- x
-  neg_0[x < 0] <- 0
-  pos_0[!x < 0] <- 0
-
-  
-    # draw the positive part
-  #h_pos <- rbind(rectbar = 0,apply(t(neg_0),2L,cumsum))
-  h_pos <- rbind(rectbase = 0,apply(t(neg_0),2L,cumsum))
-  NR_POS <- nrow(h_pos[-1,])
-  NC_POS <- ncol(h_pos)
-  #(ts_time[i]+cumsum(rep(bar_space,n_series)))
-
-  for (i in 1L:NC_POS) {
-    if(group_bar_chart){
-      coords <- find_group_coords(x,theme,i)      
-      rect(coords$xl, coords$yb,
-           coords$xr, coords$yt,
-           col = theme$bar_fill_color,
-           lwd = theme$bar_border_lwd,
-           border = theme$bar_border
-           )
-    } else{
-      rect(ts_time[i],
-           h_pos[1L:NR_POS,i],
-           ts_time[i]+1/frq,
-           h_pos[-1,i],
-           col = theme$bar_fill_color[1:NR_POS],
-           lwd = theme$bar_border_lwd,
-           border = theme$bar_border
-      )    
-    }
-  
-  }
-  
-  # draw the negative part
-  h_neg <- rbind(rectbase = 0,apply(t(pos_0),2L,cumsum))
-  for (i in 1L:NC_POS) {
-    if(group_bar_chart){
-      
-    } else{
-      rect(ts_time[i],
-           h_neg[1L:NR_POS,i],
-           ts_time[i]+1/frq,
-           h_neg[-1,i],
-           col = theme$bar_fill_color[1:NR_POS],
-           lwd = theme$bar_border_lwd,
-           border = theme$bar_border
-      )  
-    }
-      
-   
+  positives <- x
+  positives[x < 0] <- 0
+  negatives <- x
+  negatives[x > 0] <- 0
+    
+  if(!group_bar_chart || n_ts == 1) {
+    # Bars are 1/frq wide, bar_gap is in % of alloted width, half of which needs to go to each side
+    offset <- theme$bar_gap/(frq*200)
+    
+    x_pos_left <- rep(ts_time + offset, each = n_ts)
+    x_pos_right <- rep(ts_time + 1/frq - offset, each = n_ts)
+    
+    h_pos <- rbind(rectbase = 0, apply(t(positives), 2L, cumsum))
+    rect(x_pos_left,
+         h_pos[1:n_ts,],
+         x_pos_right,
+         h_pos[(1:n_ts)+1,],
+         border = theme$bar_border,
+         lwd = theme$bar_border_lwd,
+         col = theme$bar_fill_color[1:n_ts])  
+    
+    h_neg <- rbind(rectbase = 0, apply(t(negatives), 2L, cumsum))
+    rect(rep(ts_time + offset, each = n_ts),
+         h_neg[1:n_ts,],
+         rep(ts_time + 1/frq - offset, each = n_ts),
+         h_neg[(1:n_ts)+1,],
+         border = theme$bar_border,
+         lwd = theme$bar_border_lwd,
+         col = theme$bar_fill_color[1:n_ts])  
+  } else {
+    individual_offset_value <- theme$bar_gap/(n_ts*frq*200)
+    
+    inter_group_offset_value <- theme$bar_group_gap/(frq*200)
+    
+    x_pos_raw <- t(c(ts_time) + rep(1, length(ts_time)) %*% t(seq(0, 1/frq, 1/(n_ts*frq))))
+    
+    inter_group_offset <- t(rep(inter_group_offset_value, length(ts_time)) %*% t(c(1, rep(0, n_ts - 1), -1)))
+    x_pos_group <- x_pos_raw + inter_group_offset
+    
+    x_pos_final <- apply(x_pos_group, 2, function(x) {
+      seq(x[1], x[n_ts+1], length.out = n_ts+1)
+    })
+    
+    inter_bar_offset <- t(rep(individual_offset_value, length(ts_time)) %*% t(c(1, rep(1, n_ts - 1), 1)))
+    
+    rect(
+      x_pos_final[1:n_ts, ] + inter_bar_offset[1:n_ts,],
+      negatives,
+      x_pos_final[(1:n_ts)+1,] - inter_bar_offset[(1:n_ts)+1, ],
+      positives,
+      border = theme$bar_border,
+      lwd = theme$bar_border_lwd,
+      col = theme$bar_fill_color[1:n_ts]
+    )
     
   }
-
 }
-

--- a/R/themes.R
+++ b/R/themes.R
@@ -13,6 +13,7 @@
 #' @param bar_border character hex colors for the border around bars in bar charts. 
 #' @param bar_border_lwd numeric The line width of the borders of bars in barplots. Default 1
 #' @param bar_fill_color character vector of hex colors for 6 time series. 
+#' @param bar_gap numeric The width of the gap between bars, in % of space alloted to the bar.
 #' @param ci_alpha Numeric 0-255, numeric 0-1 or hey 00-FF, transparency of the confidence interval bands
 #' @param ci_colors Named colors or hex values Colors of the confidence interval bands
 #' @param ci_legend_label character A formatting template for how the ci bands should be labelled. May contain the 
@@ -116,6 +117,7 @@ init_tsplot_theme <- function(
                      ETH5 = "#91056a",
                      ETH5_60 = "#cc67a7",
                      ETH5_30 = "#e6b3d3"),
+  bar_gap = 1,
   ci_alpha = "44",
   ci_colors = line_colors,
   ci_legend_label = "%ci_value%% ci for %series%",

--- a/R/themes.R
+++ b/R/themes.R
@@ -13,8 +13,8 @@
 #' @param bar_border character hex colors for the border around bars in bar charts. 
 #' @param bar_border_lwd numeric The line width of the borders of bars in barplots. Default 1
 #' @param bar_fill_color character vector of hex colors for 6 time series. 
-#' @param bar_gap numeric The width of the gap between bars, in % of space alloted to the bar.
-#' @param bara_group_gap numeric The width of the gap between groups of bars if group_bar_chart == TRUE
+#' @param bar_gap numeric The width of the gap between bars, in \% of space alloted to the bar.
+#' @param bar_group_gap numeric The width of the gap between groups of bars if group_bar_chart is TRUE.
 #' @param ci_alpha Numeric 0-255, numeric 0-1 or hey 00-FF, transparency of the confidence interval bands
 #' @param ci_colors Named colors or hex values Colors of the confidence interval bands
 #' @param ci_legend_label character A formatting template for how the ci bands should be labelled. May contain the 
@@ -118,7 +118,7 @@ init_tsplot_theme <- function(
                      ETH5 = "#91056a",
                      ETH5_60 = "#cc67a7",
                      ETH5_30 = "#e6b3d3"),
-  bar_gap = 20,
+  bar_gap = 15,
   bar_group_gap = 10,
   ci_alpha = "44",
   ci_colors = line_colors,

--- a/R/themes.R
+++ b/R/themes.R
@@ -14,6 +14,7 @@
 #' @param bar_border_lwd numeric The line width of the borders of bars in barplots. Default 1
 #' @param bar_fill_color character vector of hex colors for 6 time series. 
 #' @param bar_gap numeric The width of the gap between bars, in % of space alloted to the bar.
+#' @param bara_group_gap numeric The width of the gap between groups of bars if group_bar_chart == TRUE
 #' @param ci_alpha Numeric 0-255, numeric 0-1 or hey 00-FF, transparency of the confidence interval bands
 #' @param ci_colors Named colors or hex values Colors of the confidence interval bands
 #' @param ci_legend_label character A formatting template for how the ci bands should be labelled. May contain the 
@@ -117,7 +118,8 @@ init_tsplot_theme <- function(
                      ETH5 = "#91056a",
                      ETH5_60 = "#cc67a7",
                      ETH5_30 = "#e6b3d3"),
-  bar_gap = 1,
+  bar_gap = 20,
+  bar_group_gap = 10,
   ci_alpha = "44",
   ci_colors = line_colors,
   ci_legend_label = "%ci_value%% ci for %series%",

--- a/man/init_tsplot_theme.Rd
+++ b/man/init_tsplot_theme.Rd
@@ -8,7 +8,7 @@
 init_tsplot_theme(auto_bottom_margin = FALSE, bar_border = "#000000",
   bar_border_lwd = 1, bar_fill_color = c(ETH8 = "#007A92", ETH8_60 =
   "#66b0c2", ETH8_30 = "#b3d7e0", ETH8_20 = "#cce5eb", ETH5 = "#91056a", ETH5_60
-  = "#cc67a7", ETH5_30 = "#e6b3d3"), bar_gap = 20, bar_group_gap = 10,
+  = "#cc67a7", ETH5_30 = "#e6b3d3"), bar_gap = 15, bar_group_gap = 10,
   ci_alpha = "44", ci_colors = line_colors,
   ci_legend_label = "\%ci_value\%\% ci for \%series\%",
   default_bottom_margin = 15, fill_up_start = FALSE,
@@ -73,7 +73,9 @@ init_tsplot_print_theme(output_wide = FALSE, margins = c(NA, 10/if
 
 \item{bar_fill_color}{character vector of hex colors for 6 time series.}
 
-\item{bar_gap}{numeric The width of the gap between bars, in % of space alloted to the bar.}
+\item{bar_gap}{numeric The width of the gap between bars, in \% of space alloted to the bar.}
+
+\item{bar_group_gap}{numeric The width of the gap between groups of bars if group_bar_chart is TRUE.}
 
 \item{ci_alpha}{Numeric 0-255, numeric 0-1 or hey 00-FF, transparency of the confidence interval bands}
 
@@ -230,8 +232,6 @@ exactly once. Defaults to '\%ci_value\% ci for \%series\%'}
 \item{yearly_ticks}{logical, should yearly ticks be shown. Defaults to TRUE.}
 
 \item{...}{All the other arguments to \code{init_tsplot_thene}}
-
-\item{bara_group_gap}{numeric The width of the gap between groups of bars if group_bar_chart == TRUE}
 }
 \description{
 The \code{\link{tsplot}} methods provide a theme argument which is used to pass on a plethora of useful defaults. These defaults are essentially stored in a list. Sometimes the user may want to tweak some of these defaults while keeping most of them. 

--- a/man/init_tsplot_theme.Rd
+++ b/man/init_tsplot_theme.Rd
@@ -8,7 +8,7 @@
 init_tsplot_theme(auto_bottom_margin = FALSE, bar_border = "#000000",
   bar_border_lwd = 1, bar_fill_color = c(ETH8 = "#007A92", ETH8_60 =
   "#66b0c2", ETH8_30 = "#b3d7e0", ETH8_20 = "#cce5eb", ETH5 = "#91056a", ETH5_60
-  = "#cc67a7", ETH5_30 = "#e6b3d3"), ci_alpha = "44",
+  = "#cc67a7", ETH5_30 = "#e6b3d3"), bar_gap = 1, ci_alpha = "44",
   ci_colors = line_colors,
   ci_legend_label = "\%ci_value\%\% ci for \%series\%",
   default_bottom_margin = 15, fill_up_start = FALSE,
@@ -72,6 +72,8 @@ init_tsplot_print_theme(output_wide = FALSE, margins = c(NA, 10/if
 \item{bar_border_lwd}{numeric The line width of the borders of bars in barplots. Default 1}
 
 \item{bar_fill_color}{character vector of hex colors for 6 time series.}
+
+\item{bar_gap}{numeric The width of the gap between bars, in % of space alloted to the bar.}
 
 \item{ci_alpha}{Numeric 0-255, numeric 0-1 or hey 00-FF, transparency of the confidence interval bands}
 

--- a/man/init_tsplot_theme.Rd
+++ b/man/init_tsplot_theme.Rd
@@ -8,8 +8,8 @@
 init_tsplot_theme(auto_bottom_margin = FALSE, bar_border = "#000000",
   bar_border_lwd = 1, bar_fill_color = c(ETH8 = "#007A92", ETH8_60 =
   "#66b0c2", ETH8_30 = "#b3d7e0", ETH8_20 = "#cce5eb", ETH5 = "#91056a", ETH5_60
-  = "#cc67a7", ETH5_30 = "#e6b3d3"), bar_gap = 1, ci_alpha = "44",
-  ci_colors = line_colors,
+  = "#cc67a7", ETH5_30 = "#e6b3d3"), bar_gap = 20, bar_group_gap = 10,
+  ci_alpha = "44", ci_colors = line_colors,
   ci_legend_label = "\%ci_value\%\% ci for \%series\%",
   default_bottom_margin = 15, fill_up_start = FALSE,
   fill_year_with_nas = TRUE, highlight_color = "#e9e9e9",
@@ -230,6 +230,8 @@ exactly once. Defaults to '\%ci_value\% ci for \%series\%'}
 \item{yearly_ticks}{logical, should yearly ticks be shown. Defaults to TRUE.}
 
 \item{...}{All the other arguments to \code{init_tsplot_thene}}
+
+\item{bara_group_gap}{numeric The width of the gap between groups of bars if group_bar_chart == TRUE}
 }
 \description{
 The \code{\link{tsplot}} methods provide a theme argument which is used to pass on a plethora of useful defaults. These defaults are essentially stored in a list. Sometimes the user may want to tweak some of these defaults while keeping most of them. 

--- a/man/tsplot.Rd
+++ b/man/tsplot.Rd
@@ -5,10 +5,10 @@
 \title{Plot Time Series}
 \usage{
 tsplot(..., tsr = NULL, ci = NULL, left_as_bar = FALSE,
-  group_bar_chart = FALSE, relative_bar_chart = FALSE, plot_title = NULL,
-  plot_subtitle = NULL, plot_subtitle_r = NULL,
-  find_ticks_function = "findTicks", overall_xlim = NULL,
-  overall_ylim = NULL, manual_date_ticks = NULL,
+  group_bar_chart = FALSE, relative_bar_chart = FALSE,
+  left_as_band = FALSE, plot_title = NULL, plot_subtitle = NULL,
+  plot_subtitle_r = NULL, find_ticks_function = "findTicks",
+  overall_xlim = NULL, overall_ylim = NULL, manual_date_ticks = NULL,
   manual_value_ticks_l = NULL, manual_value_ticks_r = NULL,
   manual_ticks_x = NULL, theme = NULL, quiet = TRUE, auto_legend = TRUE,
   output_format = "plot", filename = "tsplot",

--- a/vignettes/tstools.Rmd
+++ b/vignettes/tstools.Rmd
@@ -178,8 +178,12 @@ which implies that a bar is centered above the category tick for that period.
 ```{r,fig.width = 7,fig.height=6}
 tsplot(tsb1, tsb2, tsb3,
        left_as_bar = T,
-       auto_legend = F)
+       auto_legend = F,
+       theme = init_tsplot_theme(bar_gap = 10))
 ```
+
+Notice that the gap size of the gap between the bars can be adjusted using the **bar_gap** theme parameter.
+
 
 ## Sum as line in stacked bar charts
 
@@ -235,7 +239,7 @@ They might be more illustrative than stacked bar charts, but are subject to
 certain limitations: plots always start at zero and all series need to be 
 either positive or negative. 
 
-```{r}
+```{r,fig.width = 7,fig.height=6}
 set.seed(123)
 tslist <- generate_random_ts(4, starts = 1987:1990,
                              ranges_min = 1,


### PR DESCRIPTION
Adds the two theme parameters `bar_gap` and `bar_group_gap`.
These specify the margin between bars/groups of bars in percent of the width originally alloted to them.