### PR TITLE
Fix order mixup in new draw_ts_bars

### DIFF
--- a/R/low_level_bar_plots.R
+++ b/R/low_level_bar_plots.R
@@ -68,9 +68,9 @@ draw_ts_bars <- function(x, group_bar_chart = FALSE, theme = NULL){
     
     rect(
       x_left,
-      negatives,
+      t(negatives),
       x_right,
-      positives,
+      t(positives),
       border = theme$bar_border,
       lwd = theme$bar_border_lwd,
       col = theme$bar_fill_color[1:n_ts]

--- a/R/themes.R
+++ b/R/themes.R
@@ -119,7 +119,7 @@ init_tsplot_theme <- function(
                      ETH5_60 = "#cc67a7",
                      ETH5_30 = "#e6b3d3"),
   bar_gap = 15,
-  bar_group_gap = 10,
+  bar_group_gap = 30,
   ci_alpha = "44",
   ci_colors = line_colors,
   ci_legend_label = "%ci_value%% ci for %series%",


### PR DESCRIPTION
Simple transpose of the y values did the trick.

Credit to feckert (what's his github handle again?) for spotting the bug.

Fixes #244