### PR TITLE
make long_to_ts handle series of length 1

### DIFF
--- a/R/import_helpers.R
+++ b/R/import_helpers.R
@@ -59,14 +59,21 @@ long_to_ts <- function(data, keep_last_freq_only = FALSE, force_xts = FALSE) {
           list(ts_object = list(xts(value, order.by = as.Date(date))))
         } else if(frq[1] == 4) {
           list(ts_object = list(xts(value, order.by = as.yearqtr(date_zoo))))
+        # TODO: This case also (wrongly) catches series of length 1
         } else {
           list(ts_object = list(xts(value, order.by = as.yearmon(date_zoo))))
         }
       }
       
     } else {
-      list(ts_object = list(ts(value, start = .SD[1, date_zoo],
-                               end = .SD[.N, date_zoo], deltat = dT[1])))
+      if(length(dT) > 0) {
+        list(ts_object = list(ts(value, start = .SD[1, date_zoo],
+                                 end = .SD[.N, date_zoo], deltat = dT[1])))
+      } else {
+        # "series" of length 1 need special treatment as frequency cannot be determined
+        list(ts_object = list(ts(value, start = .SD[1, date_zoo],
+                                 end = .SD[.N, date_zoo], deltat = 1)))
+      }
     }
   }, by = series]
   


### PR DESCRIPTION
Previously it would crash when such series appeared in the
data. Straight out stripping them might not always be the
desired behavior.

Another issue with the na.trim step here (in addition to the
numeric imprecisions it introduces in the dates) is that it
appears to round up the year of the (single observation) series.