### PR TITLE
Make read_swissdata handle zero padded dims correctly

### DIFF
--- a/R/read_swissdata.R
+++ b/R/read_swissdata.R
@@ -33,7 +33,10 @@ read_swissdata <- function(path, key_columns = NULL, filter = NULL,
     key_columns <- meta$dim.order
   }
   
-  raw <- fread(path)
+  # Read all columns as character to preserve things like
+  # 00, 012 etc. in dims
+  raw <- fread(path, colClasses = "character")
+  raw[, value := as.numeric(value)]
   
   # TODO!!! Document change in aggregates param
   if(!is.null(aggregates)) {


### PR DESCRIPTION
When using plain fread, dimensions with ids made up of numbers
are interpreted as numbers (naturally). However such ids need to
be treated as strings so as not to cause discrepancies with metadata.
e.g. a key 00 would be read as just 0.