### PR TITLE
long_to_ts use tstools:: instead of na.trim

### DIFF
--- a/R/import_helpers.R
+++ b/R/import_helpers.R
@@ -19,10 +19,13 @@ json_to_ts <- function(json_data) {
 #' should only the part of the series be returned that has the same frequency as 
 #' the last observation. This is useful when data start out crappy and then stabilize 
 # after a while. Defaults to FALSE. Hence only the last part of the series is returned.
+#' @param force_xts logical
+#' @param strip_nas logical should NAs be stripped (no leading and trailing nas) ?
 #' @importFrom data.table dcast
 #' @importFrom zoo na.trim
 #' @export
-long_to_ts <- function(data, keep_last_freq_only = FALSE, force_xts = FALSE) {
+long_to_ts <- function(data, keep_last_freq_only = FALSE, force_xts = FALSE,
+                       strip_nas = TRUE) {
   data_dt <- as.data.table(data)
   
   # Strip series consisting only of NAs
@@ -76,9 +79,12 @@ long_to_ts <- function(data, keep_last_freq_only = FALSE, force_xts = FALSE) {
                                   "\n\nFrequency cannot be detected in time series of length 1!")
   
   tslist <- dt_of_lists[, ts_object]
-  tslist <- lapply(tslist, function(x) {
-    strip_ts_of_leading_nas(strip_ts_of_trailing_nas(x))
-  })
+  if(strip_nas){
+    tslist <- lapply(tslist, function(x) {
+      strip_ts_of_leading_nas(strip_ts_of_trailing_nas(x))
+    })  
+  }
+  
   names(tslist) <- dt_of_lists[, series]
   tslist
 }

--- a/R/import_helpers.R
+++ b/R/import_helpers.R
@@ -76,7 +76,9 @@ long_to_ts <- function(data, keep_last_freq_only = FALSE, force_xts = FALSE) {
                                   "\n\nFrequency cannot be detected in time series of length 1!")
   
   tslist <- dt_of_lists[, ts_object]
-  tslist <- lapply(tslist, na.trim)
+  tslist <- lapply(tslist, function(x) {
+    strip_ts_of_leading_nas(strip_ts_of_trailing_nas(x))
+  })
   names(tslist) <- dt_of_lists[, series]
   tslist
 }

--- a/man/long_to_ts.Rd
+++ b/man/long_to_ts.Rd
@@ -4,7 +4,8 @@
 \alias{long_to_ts}
 \title{Transform a long format data.frame of time series to a tslist}
 \usage{
-long_to_ts(data, keep_last_freq_only = FALSE, force_xts = FALSE)
+long_to_ts(data, keep_last_freq_only = FALSE, force_xts = FALSE,
+  strip_nas = TRUE)
 }
 \arguments{
 \item{data}{data.frame The data.frame to be transformed}
@@ -12,6 +13,10 @@ long_to_ts(data, keep_last_freq_only = FALSE, force_xts = FALSE)
 \item{keep_last_freq_only}{in case there is a frequency change in a time series, 
 should only the part of the series be returned that has the same frequency as 
 the last observation. This is useful when data start out crappy and then stabilize}
+
+\item{force_xts}{logical}
+
+\item{strip_nas}{logical should NAs be stripped (no leading and trailing nas) ?}
 }
 \description{
 The data.frame must have three columns "date", "value" and "series" (identifying the time series)


### PR DESCRIPTION
Somehow, the `as.zoo` in `zoo::na.trim.ts` rounds December (2019.917) to Jan of the next year.

Use tstool's own na strippers to avoid this.

Closes #286