### PR TITLE
Add json support to read_swissdata[_meta]

### DIFF
--- a/R/read_swissdata.R
+++ b/R/read_swissdata.R
@@ -29,7 +29,15 @@ read_swissdata <- function(path, key_columns = NULL, filter = NULL,
   dataset <- gsub("\\.csv","",basename(path))
   
   if(is.null(key_columns)) {
-    meta <- yaml::read_yaml(gsub("csv$", "yaml", path))
+    set_id <- gsub(".csv$", "", basename(path))
+    
+    meta <- .read_swissdata_meta_unknown_format(gsub(".csv", "", path))
+    
+    if(length(meta) == 0) {
+      # Alternatively: Take them as they come in the csv?
+      stop("Neither JSON nor YAML metadata found and key_columns not specified. Cannot proceed!")
+    }
+    
     key_columns <- meta$dim.order
   }
   


### PR DESCRIPTION
`read_swissdata` and `read_swissdata_meta` now support JSON format metadata and try to determine the format automatically, if it is not known (especially in `read_swissdata` as only the CSV-File is known there.