### PR TITLE
Fix issue #298: use melt from data.table instead of from deprecated reshape2

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -35,10 +35,11 @@ Suggests:
     openxlsx,
     reshape2,
     rmarkdown,
-    testthat
+    testthat (>= 3.0.0)
 VignetteBuilder:
     knitr
 Encoding: UTF-8
 LazyData: true
 NeedsCompilation: no
 RoxygenNote: 7.2.3
+Config/testthat/edition: 3

--- a/R/import_helpers.R
+++ b/R/import_helpers.R
@@ -114,26 +114,34 @@ utils::globalVariables(c("date_zoo", "series", "ts_object", "value", "frq", "is_
 
 #' Transform a wide format data.frame into a tslist
 #'
-#' The time series in the data.frame may be stored either rowwise or columnswise.
-#' The identifying column must be called date (for columnwise) or series (for rowwise)
+#' The time series in the data.frame may be stored either rowwise or
+#' columnswise.
+#' The identifying column must be called date (for columnwise) or series
+#' (for rowwise)
 #' @param data data.frame The data.frame to be transformed
-#' @param keep_last_freq_only in case there is a frequency change in a time series,
-#' should only the part of the series be returned that has the same frequency as
-#' the last observation. This is useful when data start out crappy and then stabilize
-#' after a while. Defaults to FALSE. Hence only the last part of the series is returned.
+#' @param keep_last_freq_only in case there is a frequency change in a time
+#' series, should only the part of the series be returned that has the same
+#' frequency as the last observation.
+#' This is useful when data start out crappy and then stabilize after a while.
+#' Defaults to FALSE. Hence only the last part of the series is returned.
 #' @param force_xts boolean force xts format? Defaults to FALSE.
 #' @importFrom xts xts
 #' @importFrom zoo as.yearqtr as.yearmon
 #' @export
 wide_to_ts <- function(data, keep_last_freq_only = FALSE, force_xts = FALSE) {
+  # Convert to data.table
+  data.table::setDT(data)
+
   if (!("date" %in% names(data))) {
     # Data was written in transposed format
-    long_to_ts(melt(data, id.vars = "series", variable.name = "date"),
+    long_to_ts(
+      data.table::melt(data, id.vars = "series", variable.name = "date"),
       keep_last_freq_only = keep_last_freq_only,
       force_xts = force_xts
     )
   } else {
-    long_to_ts(melt(data, id.vars = "date", variable.name = "series"),
+    long_to_ts(
+      data.table::melt(data, id.vars = "date", variable.name = "series"),
       keep_last_freq_only = keep_last_freq_only,
       force_xts = force_xts
     )

--- a/tests/testthat.R
+++ b/tests/testthat.R
@@ -1,0 +1,12 @@
+# This file is part of the standard setup for testthat.
+# It is recommended that you do not modify it.
+#
+# Where should you do additional test configuration?
+# Learn more about the roles of various files in:
+# * https://r-pkgs.org/testing-design.html#sec-tests-files-overview
+# * https://testthat.r-lib.org/articles/special-files.html
+
+library(testthat)
+library(tstools)
+
+test_check("tstools")

--- a/tests/testthat/test-import_helpers.R
+++ b/tests/testthat/test-import_helpers.R
@@ -1,0 +1,16 @@
+test_that("wide_to_ts", {
+  df <- data.frame(
+    date = c("2024 Q1", "2024 Q2", "2024 Q3", "2024 Q4"),
+    gdp = c(100, 105, 110, 120),
+    cpi = c(2.1, 2.2, 2.3, 2.5)
+  )
+
+  out <- wide_to_ts(df)
+
+  expected <- list(
+    gdp = structure(c(100, 105, 110, 120), tsp = c(2024, 2024.75, 4), class = "ts"),
+    cpi = structure(c(2.1, 2.2, 2.3, 2.5), tsp = c(2024, 2024.75, 4), class = "ts")
+  )
+
+  expect_equal(out, expected)
+})


### PR DESCRIPTION
Should fix the issue #298 